### PR TITLE
Clean up macros

### DIFF
--- a/macros/src/main/scala/com/unstablebuild/slime/AnnotatedInstance.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/AnnotatedInstance.scala
@@ -1,0 +1,7 @@
+package com.unstablebuild.slime
+
+case class AnnotatedInstance[T](instance: T, encoder: TypeEncoder[T]) {
+
+  def encoded: Seq[(String, Value)] = encoder.encode(instance)
+
+}

--- a/macros/src/main/scala/com/unstablebuild/slime/AnnotationMarker.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/AnnotationMarker.scala
@@ -1,0 +1,22 @@
+package com.unstablebuild.slime
+
+import java.util
+
+import org.slf4j.Marker
+
+import scala.collection.JavaConverters._
+
+class AnnotationMarker(val annotations: Seq[AnnotatedInstance[_]]) extends Marker {
+
+  def encoded: Seq[(String, Value)] = annotations.flatMap(_.encoded)
+
+  override def hasChildren: Boolean = false
+  override def getName: String = "annotation-marker"
+  override def remove(reference: Marker): Boolean = false
+  override def contains(other: Marker): Boolean = false
+  override def contains(name: String): Boolean = false
+  override def iterator(): util.Iterator[Marker] = Iterator.empty.asJava
+  override def add(reference: Marker): Unit = ()
+  override def hasReferences: Boolean = false
+
+}

--- a/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
@@ -1,0 +1,7 @@
+package com.unstablebuild.slime
+
+trait TypeEncoder[-T] {
+
+  def encode(instance: T): Seq[(String, Value)]
+
+}

--- a/macros/src/main/scala/com/unstablebuild/slime/Value.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/Value.scala
@@ -1,0 +1,10 @@
+package com.unstablebuild.slime
+
+sealed trait Value
+
+sealed trait SingleValue extends Value
+
+case class StringValue(value: String) extends SingleValue
+case class NumberValue(value: Number) extends SingleValue
+
+case class NestedValue(values: Seq[(String, Value)]) extends Value

--- a/src/main/scala/com/unstablebuild/slime/oi.scala
+++ b/src/main/scala/com/unstablebuild/slime/oi.scala
@@ -192,7 +192,7 @@ It is a Scala only library
 
  */
 
-@slimeLogger
+@SlimeLogger
 class MacroLogger extends Logger {}
 
 object MacroLoggerTest extends App with encoders {


### PR DESCRIPTION
- Break down the single `oi.scala` file into multiple files;
- Use a helper class (`LoggerGenerator`) to work with macros, as explained [here](http://docs.scala-lang.org/overviews/macros/overview.html#writing-bigger-macros):

> One of the approaches is to write a class that takes a parameter of type Context and then split the macro implementation into a series of methods of that class.

I'm not using any of the approach they suggested to eliminate the type confusion. Instead I'm doing the more simple and ugly alternative of using `result.asInstanceOf[c.Tree]`.