### PR TITLE
Organize encoders

### DIFF
--- a/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
@@ -5,9 +5,3 @@ trait TypeEncoder[-T] {
   def encode(instance: T): Seq[(String, Value)]
 
 }
-
-class KeyedValueEncoder[V](val convert: V => Value) extends TypeEncoder[(String, V)] {
-
-  override def encode(instance: (String, V)): Seq[(String, Value)] = Seq((instance._1, convert(instance._2)))
-
-}

--- a/macros/src/main/scala/com/unstablebuild/slime/Value.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/Value.scala
@@ -9,7 +9,6 @@ object SingleValue {
   def unapply(value: SingleValue): Option[Any] = value match {
     case StringValue(s) => Some(s)
     case NumberValue(n) => Some(n)
-    case CharValue(c) => Some(c)
     case BooleanValue(b) => Some(b)
   }
 
@@ -17,7 +16,6 @@ object SingleValue {
 
 case class StringValue(value: String) extends SingleValue
 case class NumberValue[N: Numeric](value: N) extends SingleValue
-case class CharValue(value: Char) extends SingleValue
 case class BooleanValue(value: Boolean) extends SingleValue
 
 case class SeqValue(values: Seq[Value]) extends Value

--- a/src/main/scala/com/unstablebuild/slime/Encodable.scala
+++ b/src/main/scala/com/unstablebuild/slime/Encodable.scala
@@ -1,7 +1,0 @@
-package com.unstablebuild.slime
-
-trait Encodable {
-
-  def encoded: Seq[(String, Value)]
-
-}

--- a/src/main/scala/com/unstablebuild/slime/Encoders.scala
+++ b/src/main/scala/com/unstablebuild/slime/Encoders.scala
@@ -2,12 +2,47 @@ package com.unstablebuild.slime
 
 import java.io.{PrintWriter, StringWriter}
 
-trait Encoders extends KeyedEncoders {
+import scala.collection.GenTraversable
 
-  implicit object throwableEncoder extends TypeEncoder[Throwable] {
-    override def encode(instance: Throwable): Seq[(String, Value)] =
-      Seq("exception" -> keyedThrowableEncoder.convert(instance))
+trait Encoders extends LowPriorityEncoders {
+
+  implicit val stringValuable: Valuable[String] = s => StringValue(s)
+  implicit val symbolValuable: Valuable[Symbol] = s => StringValue(s.name)
+  implicit val charValuable: Valuable[Char] = c => StringValue(c.toString)
+  implicit def numberValuable[N: Numeric]: Valuable[N] = n => NumberValue(n)
+  implicit val boolValuable: Valuable[Boolean] = b => BooleanValue(b)
+  implicit val throwableValuable: Valuable[Throwable] = { e =>
+    val stackTrace = new StringWriter()
+    val writer = new PrintWriter(stackTrace)
+    e.printStackTrace(writer)
+    writer.flush()
+    writer.close()
+    NestedValue(Seq("message" -> StringValue(e.getMessage), "stack" -> StringValue(new String(stackTrace.toString))))
   }
+
+  implicit val stringKey: Keyable[String] = (s: String) => s
+  implicit val symbolKey: Keyable[Symbol] = (s: Symbol) => s.name
+
+  implicit def traversableCollection[A, C[_] <: GenTraversable[_]]: Collection[A, C] =
+    (traversable: C[A]) => traversable.seq.asInstanceOf[Traversable[A]]
+
+  implicit def arrayCollection[A]: Collection[A, Array] =
+    (array: Array[A]) => array.toTraversable
+
+  implicit def optionCollection[A]: Collection[A, Option] =
+    (opt: Option[A]) => opt.toTraversable
+
+  implicit def keyValueEncoder[K: Keyable, V: Valuable]: TypeEncoder[(K, V)] = (instance: (K, V)) => {
+    Seq(implicitly[Keyable[K]].get(instance._1) -> implicitly[Valuable[V]].get(instance._2))
+  }
+
+  implicit def traversableValuable[V, C[_]](implicit value: Valuable[V],
+                                            collection: Collection[V, C]): Valuable[C[V]] =
+    t => SeqValue(collection.traversable(t).map(v => value.get(v)).toSeq)
+
+  implicit def traversablePairEncoder[K, V, C[_]](implicit te: TypeEncoder[(K, V)],
+                                                  collection: Collection[(K, V), C]): TypeEncoder[C[(K, V)]] =
+    t => collection.traversable(t).flatMap(te.encode).toSeq
 
   implicit object encodableEncoder extends TypeEncoder[Encodable] {
     override def encode(instance: Encodable): Seq[(String, Value)] = instance.encoded
@@ -15,52 +50,26 @@ trait Encoders extends KeyedEncoders {
 
 }
 
-trait KeyedEncoders {
+// https://stackoverflow.com/a/1887678
+trait LowPriorityEncoders {
 
-  implicit object keyedStringEncoder extends KeyedValueEncoder[String](s => StringValue(s))
-  implicit object keyedBooleanEncoder extends KeyedValueEncoder[Boolean](c => BooleanValue(c))
-  implicit object keyedCharEncoder extends KeyedValueEncoder[Char](c => CharValue(c))
-  implicit def keyedNumberEncoder[N: Numeric]: KeyedValueEncoder[N] = new KeyedValueEncoder[N](n => NumberValue(n))
+  implicit def keyOtherEncoder[K: Keyable, V: TypeEncoder]: TypeEncoder[(K, V)] = (instance: (K, V)) => {
+    Seq(implicitly[Keyable[K]].get(instance._1) -> NestedValue(implicitly[TypeEncoder[V]].encode(instance._2)))
+  }
 
-  implicit object keyedSymbolEncoder extends KeyedValueEncoder[Symbol](s => StringValue(s.name))
+  implicit def throwableEncoder(implicit throwableValuable: Valuable[Throwable]): TypeEncoder[Throwable] =
+    instance => Seq("exception" -> throwableValuable.get(instance))
 
-  implicit def keyedSeqEncoder[T](implicit te: KeyedValueEncoder[T]): KeyedValueEncoder[Seq[T]] =
-    new KeyedValueEncoder[Seq[T]](seq => SeqValue(seq.map(te.convert)))
-  implicit def keyedSeqTypeEncoder[T](implicit te: TypeEncoder[T]): KeyedValueEncoder[Seq[T]] =
-    new KeyedValueEncoder[Seq[T]](seq => SeqValue(seq.map(te.encode).map(NestedValue)))
+}
 
-  implicit def keyedSetEncoder[T](implicit te: KeyedValueEncoder[T]): KeyedValueEncoder[Set[T]] =
-    new KeyedValueEncoder[Set[T]](seq => SeqValue(seq.map(te.convert).toSeq))
-  implicit def keyedSetTypeEncoder[T](implicit te: TypeEncoder[T]): KeyedValueEncoder[Set[T]] =
-    new KeyedValueEncoder[Set[T]](seq => SeqValue(seq.map(te.encode).map(NestedValue).toSeq))
+trait Keyable[T] {
+  def get(key: T): String
+}
 
-  implicit def keyedMapEncoder[V](implicit te: KeyedValueEncoder[V]): KeyedValueEncoder[Map[String, V]] =
-    new KeyedValueEncoder[Map[String, V]](map => NestedValue(map.mapValues(te.convert).toSeq))
-  implicit def symbolKeyedMapEncoder[V](implicit te: KeyedValueEncoder[V]): KeyedValueEncoder[Map[Symbol, V]] =
-    new KeyedValueEncoder[Map[Symbol, V]](map => NestedValue(map.map { case (k, v) => k.name -> te.convert(v) }.toSeq))
+trait Valuable[-T] {
+  def get(instance: T): Value
+}
 
-  implicit object keyedThrowableEncoder
-      extends KeyedValueEncoder[Throwable]({ e =>
-        val stackTrace = new StringWriter()
-        val writer = new PrintWriter(stackTrace)
-        e.printStackTrace(writer)
-        writer.flush()
-        writer.close()
-        NestedValue(
-          Seq("message" -> StringValue(e.getMessage), "stack" -> StringValue(new String(stackTrace.toString)))
-        )
-      })
-
-  implicit def symbolKeyedTypeEncoder[T](implicit te: TypeEncoder[(String, T)]): TypeEncoder[(Symbol, T)] =
-    (instance: (Symbol, T)) => {
-      val (key, value) = instance
-      te.encode(key.name -> value)
-    }
-
-  implicit def keyedTypeEncoder[V](implicit te: TypeEncoder[V]): TypeEncoder[(String, V)] =
-    (instance: (String, V)) => {
-      val (outer, value) = instance
-      Seq(outer -> NestedValue(te.encode(value)))
-    }
-
+trait Collection[A, C[_]] {
+  def traversable(collection: C[A]): Traversable[A]
 }

--- a/src/main/scala/com/unstablebuild/slime/Logging.scala
+++ b/src/main/scala/com/unstablebuild/slime/Logging.scala
@@ -1,6 +1,6 @@
 package com.unstablebuild.slime
 
-trait Logging {
+trait Logging extends TypeEncoders {
 
   protected def logger: Logger
 

--- a/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
+++ b/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
@@ -44,10 +44,6 @@ trait TypeEncoders extends LowPriorityTypeEncoders {
                                                   collection: Collection[(K, V), C]): TypeEncoder[C[(K, V)]] =
     t => collection.traversable(t).flatMap(te.encode).toSeq
 
-  implicit object encodableEncoder extends TypeEncoder[Encodable] {
-    override def encode(instance: Encodable): Seq[(String, Value)] = instance.encoded
-  }
-
 }
 
 // https://stackoverflow.com/a/1887678

--- a/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
+++ b/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
@@ -4,7 +4,7 @@ import java.io.{PrintWriter, StringWriter}
 
 import scala.collection.GenTraversable
 
-trait Encoders extends LowPriorityEncoders {
+trait TypeEncoders extends LowPriorityTypeEncoders {
 
   implicit val stringValuable: Valuable[String] = s => StringValue(s)
   implicit val symbolValuable: Valuable[Symbol] = s => StringValue(s.name)
@@ -51,7 +51,7 @@ trait Encoders extends LowPriorityEncoders {
 }
 
 // https://stackoverflow.com/a/1887678
-trait LowPriorityEncoders {
+trait LowPriorityTypeEncoders {
 
   implicit def keyOtherEncoder[K: Keyable, V: TypeEncoder]: TypeEncoder[(K, V)] = (instance: (K, V)) => {
     Seq(implicitly[Keyable[K]].get(instance._1) -> NestedValue(implicitly[TypeEncoder[V]].encode(instance._2)))

--- a/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
+++ b/src/main/scala/com/unstablebuild/slime/TypeEncoders.scala
@@ -23,18 +23,17 @@ trait TypeEncoders extends LowPriorityTypeEncoders {
   implicit val stringKey: Keyable[String] = (s: String) => s
   implicit val symbolKey: Keyable[Symbol] = (s: Symbol) => s.name
 
-  implicit def traversableCollection[A, C[_] <: GenTraversable[_]]: Collection[A, C] =
-    (traversable: C[A]) => traversable.seq.asInstanceOf[Traversable[A]]
+  implicit def traversableCollection[V, C[_] <: GenTraversable[_]]: Collection[V, C] =
+    (traversable: C[V]) => traversable.seq.asInstanceOf[Traversable[V]]
 
-  implicit def arrayCollection[A]: Collection[A, Array] =
-    (array: Array[A]) => array.toTraversable
+  implicit def arrayCollection[V]: Collection[V, Array] =
+    (array: Array[V]) => array.toTraversable
 
-  implicit def optionCollection[A]: Collection[A, Option] =
-    (opt: Option[A]) => opt.toTraversable
+  implicit def optionCollection[V]: Collection[V, Option] =
+    (opt: Option[V]) => opt.toTraversable
 
-  implicit def keyValueEncoder[K: Keyable, V: Valuable]: TypeEncoder[(K, V)] = (instance: (K, V)) => {
-    Seq(implicitly[Keyable[K]].get(instance._1) -> implicitly[Valuable[V]].get(instance._2))
-  }
+  implicit def keyValueEncoder[K: Keyable, V: Valuable]: TypeEncoder[(K, V)] =
+    (instance: (K, V)) => Seq(implicitly[Keyable[K]].get(instance._1) -> implicitly[Valuable[V]].get(instance._2))
 
   implicit def traversableValuable[V, C[_]](implicit value: Valuable[V],
                                             collection: Collection[V, C]): Valuable[C[V]] =
@@ -58,14 +57,14 @@ trait LowPriorityTypeEncoders {
 
 }
 
-trait Keyable[T] {
-  def get(key: T): String
+trait Keyable[K] {
+  def get(key: K): String
 }
 
-trait Valuable[-T] {
-  def get(instance: T): Value
+trait Valuable[-V] {
+  def get(instance: V): Value
 }
 
-trait Collection[A, C[_]] {
-  def traversable(collection: C[A]): Traversable[A]
+trait Collection[V, C[_]] {
+  def traversable(collection: C[V]): Traversable[V]
 }

--- a/src/main/scala/com/unstablebuild/slime/format/Json.scala
+++ b/src/main/scala/com/unstablebuild/slime/format/Json.scala
@@ -14,7 +14,6 @@ class Json extends Format {
     case SeqValue(values) => values.map(formatValue).mkString("[", ",", "]")
     case StringValue(str) => "\"" + str.replaceAll("\n", "\\\\n").replaceAll("\t", "\\\\t") + "\""
     case NumberValue(num) => num.toString
-    case CharValue(c) => "\"" + c.toString + "\""
     case BooleanValue(b) => b.toString
     case NestedValue(values) => formatNested(values)
   }

--- a/src/main/scala/com/unstablebuild/slime/package.scala
+++ b/src/main/scala/com/unstablebuild/slime/package.scala
@@ -1,3 +1,3 @@
 package com.unstablebuild
 
-package object slime extends Encoders {}
+package object slime

--- a/src/test/scala/com/unstablebuild/slime/EncodersTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/EncodersTest.scala
@@ -1,0 +1,116 @@
+package com.unstablebuild.slime
+
+import org.scalatest.{FlatSpec, MustMatchers}
+
+import scala.collection.{immutable, mutable}
+import scala.util.control.NoStackTrace
+
+class EncodersTest extends FlatSpec with MustMatchers with Encoders {
+
+  it must "encode keyed and non-keyed exceptions" in {
+    val exception = new Exception("BOOM!!!") with NoStackTrace
+    val stack = exception.toString + "\n"
+    encode(exception) must equal(
+      Seq("exception" -> NestedValue(Seq("message" -> StringValue("BOOM!!!"), "stack" -> StringValue(stack))))
+    )
+    encode("error" -> exception) must equal(
+      Seq("error" -> NestedValue(Seq("message" -> StringValue("BOOM!!!"), "stack" -> StringValue(stack))))
+    )
+  }
+
+  it must "encode keyed primitive types" in {
+
+    encode("hello" -> "world") must equal(Seq("hello" -> StringValue("world")))
+    encode("hello" -> 'world) must equal(Seq("hello" -> StringValue("world")))
+
+    encode("hello" -> 123) must equal(Seq("hello" -> NumberValue(123)))
+    encode("hello" -> 123L) must equal(Seq("hello" -> NumberValue(123L)))
+    encode("hello" -> 3.14f) must equal(Seq("hello" -> NumberValue(3.14f)))
+    encode("hello" -> 3.14d) must equal(Seq("hello" -> NumberValue(3.14d)))
+    encode("hello" -> BigInt(1)) must equal(Seq("hello" -> NumberValue(BigInt(1))))
+
+    encode("hello" -> true) must equal(Seq("hello" -> BooleanValue(true)))
+    encode("hello" -> false) must equal(Seq("hello" -> BooleanValue(false)))
+
+    encode("hello" -> 'y') must equal(Seq("hello" -> StringValue("y")))
+  }
+
+  it must "encode types keyed by symbol or string" in {
+
+    encode('hello -> "world") must equal(Seq("hello" -> StringValue("world")))
+    encode('hello -> 123) must equal(Seq("hello" -> NumberValue(123)))
+    encode('hello -> true) must equal(Seq("hello" -> BooleanValue(true)))
+    encode('hello -> 'y') must equal(Seq("hello" -> StringValue("y")))
+  }
+
+  it must "encode collections" in {
+
+    encode("hello" -> Array(1, 2, 3)) must equal(
+      Seq("hello" -> SeqValue(Seq(NumberValue(1), NumberValue(2), NumberValue(3))))
+    )
+    encode("hello" -> Array('a -> ('b -> 2))) must equal(
+      Seq("hello" -> NestedValue(Seq("a" -> NestedValue(Seq("b" -> NumberValue(2))))))
+    )
+    encode(Array('a -> 1, 'b -> 2)) must equal(Seq("a" -> NumberValue(1), "b" -> NumberValue(2)))
+
+    encode("hello" -> Seq(1, 2, 3)) must equal(
+      Seq("hello" -> SeqValue(Seq(NumberValue(1), NumberValue(2), NumberValue(3))))
+    )
+    encode("hello" -> List(1, 2, 3)) must equal(
+      Seq("hello" -> SeqValue(Seq(NumberValue(1), NumberValue(2), NumberValue(3))))
+    )
+    encode("hello" -> mutable.ListBuffer(1, 2, 3)) must equal(
+      Seq("hello" -> SeqValue(Seq(NumberValue(1), NumberValue(2), NumberValue(3))))
+    )
+
+    encode("hello" -> Set(1)) must equal(Seq("hello" -> SeqValue(Seq(NumberValue(1)))))
+    encode("hello" -> immutable.HashSet(1)) must equal(Seq("hello" -> SeqValue(Seq(NumberValue(1)))))
+
+    encode("hello" -> Set('a -> 1)) must equal(Seq("hello" -> NestedValue(Seq("a" -> NumberValue(1)))))
+    encode("hello" -> Set('a -> ('b -> 2))) must equal(
+      Seq("hello" -> NestedValue(Seq("a" -> NestedValue(Seq("b" -> NumberValue(2))))))
+    )
+
+    encode("hello" -> Seq(1, 2, 3).par) must equal(
+      Seq("hello" -> SeqValue(Seq(NumberValue(1), NumberValue(2), NumberValue(3))))
+    )
+
+    encode(Map('a -> 1, 'b -> 2)) must equal(Seq("a" -> NumberValue(1), "b" -> NumberValue(2)))
+    encode("hello" -> Map('a -> 1, 'b -> 2)) must equal(
+      Seq("hello" -> NestedValue(Seq("a" -> NumberValue(1), "b" -> NumberValue(2))))
+    )
+    encode("hello" -> Map('a -> Map("a" -> 1), 'b -> Map("b" -> 2))) must equal(
+      Seq(
+        "hello" -> NestedValue(
+          Seq("a" -> NestedValue(Seq("a" -> NumberValue(1))), "b" -> NestedValue(Seq("b" -> NumberValue(2))))
+        )
+      )
+    )
+
+    encode(Seq('a -> 1, 'b -> 2)) must equal(Seq("a" -> NumberValue(1), "b" -> NumberValue(2)))
+    encode("hello" -> Seq('a -> 1, 'b -> 2)) must equal(
+      Seq("hello" -> NestedValue(Seq("a" -> NumberValue(1), "b" -> NumberValue(2))))
+    )
+  }
+
+  it must "encode options" in {
+    encode("hello" -> Option.empty[String]) must equal(Seq("hello" -> SeqValue(Seq.empty)))
+    encode("hello" -> Option("hi")) must equal(Seq("hello" -> SeqValue(Seq(StringValue("hi")))))
+  }
+
+  it must "encode encodable types" in {
+
+    case class MyPair(int: Int, str: String) extends Encodable {
+      override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
+    }
+
+    encode(MyPair(1, "a")) must equal(Seq("int" -> NumberValue(1), "str" -> StringValue("a")))
+    encode("keyed" -> MyPair(2, "b")) must equal(
+      Seq("keyed" -> NestedValue(Seq("int" -> NumberValue(2), "str" -> StringValue("b"))))
+    )
+  }
+
+  def encode[T](instance: T)(implicit te: TypeEncoder[T]): Seq[(String, Value)] =
+    te.encode(instance)
+
+}

--- a/src/test/scala/com/unstablebuild/slime/LoggerTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/LoggerTest.scala
@@ -1,0 +1,3 @@
+package com.unstablebuild.slime
+
+class LoggerTest {}

--- a/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, MustMatchers}
 import scala.collection.{immutable, mutable}
 import scala.util.control.NoStackTrace
 
-class EncodersTest extends FlatSpec with MustMatchers with Encoders {
+class TypeEncodersTest extends FlatSpec with MustMatchers with TypeEncoders {
 
   it must "encode keyed and non-keyed exceptions" in {
     val exception = new Exception("BOOM!!!") with NoStackTrace

--- a/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
@@ -98,18 +98,6 @@ class TypeEncodersTest extends FlatSpec with MustMatchers with TypeEncoders {
     encode("hello" -> Option("hi")) must equal(Seq("hello" -> SeqValue(Seq(StringValue("hi")))))
   }
 
-  it must "encode encodable types" in {
-
-    case class MyPair(int: Int, str: String) extends Encodable {
-      override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
-    }
-
-    encode(MyPair(1, "a")) must equal(Seq("int" -> NumberValue(1), "str" -> StringValue("a")))
-    encode("keyed" -> MyPair(2, "b")) must equal(
-      Seq("keyed" -> NestedValue(Seq("int" -> NumberValue(2), "str" -> StringValue("b"))))
-    )
-  }
-
   def encode[T](instance: T)(implicit te: TypeEncoder[T]): Seq[(String, Value)] =
     te.encode(instance)
 

--- a/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
+++ b/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
@@ -43,11 +43,4 @@ object LoggerExamples extends App with LazyLogging {
 
   logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
 
-  case class SomeType(int: Int, str: String) extends Encodable {
-    override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
-  }
-
-  logger.info("encodable", SomeType(1, "a"))
-  logger.info("encodable", "keyed" -> SomeType(2, "b"))
-
 }

--- a/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
+++ b/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
@@ -2,9 +2,7 @@ package com.unstablebuild.slime.examples
 
 import com.unstablebuild.slime._
 
-object LoggerExamples extends App with TypeEncoders {
-
-  val logger = Logger("hi")
+object LoggerExamples extends App with LazyLogging {
 
   logger.info("oi")
   logger.info("oi", "and" -> "tchau")

--- a/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
+++ b/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
@@ -6,50 +6,50 @@ object LoggerExamples extends App {
 
   val logger = Logger("hi")
 
-  logger.info("oi")
-  logger.info("oi", "and" -> "tchau")
-
-  locally {
-    // could drop the first field and just use a type encoder that will transform a string into a message
-
-    implicit object stringEncoder extends TypeEncoder[String] {
-      override def encode(instance: String): Seq[(String, Value)] =
-        Seq("message" -> StringValue(instance))
-    }
-
-    implicit object symbolEncoder extends TypeEncoder[Symbol] {
-      override def encode(instance: Symbol): Seq[(String, Value)] =
-        Seq("message" -> StringValue(instance.name))
-    }
-
-    logger.info("oi", "oi")
-    logger.info("oi", 'oi_there)
-  }
-
-  logger.info("log message", "hello" -> 123, "world" -> 456, "!" -> 789.0, "a" -> true, "b" -> 'b')
-
-  logger.info("log message", 'symbol -> 123)
-  logger.info("log message", 'symbol -> 'to_symbol)
-
-  logger.info("sequence", "numbers" -> Seq(1, 2, 3))
-  logger.info("set", "chars" -> Set('a', 'b', 'c'))
-  logger.info("map", "ages" -> Map("me" -> 10, "you" -> 12))
-  logger.info("map", "ages" -> Map('me -> 10, 'you -> 12))
-
-  logger.info("sequence", "numbers" -> Seq("vai" -> 123))
-  logger.info("sequence", "numbers" -> Set("foi" -> 789))
-  logger.info("sequence", "numbers" -> Map("is" -> Map("nested" -> Map("down" -> true, "up" -> false))))
-
-  logger.info("exception", new Exception("ex1"))
-  logger.info("exception pair", "first" -> new Exception("ex2"))
-
-  logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
-
-  case class SomeType(int: Int, str: String) extends Encodable {
-    override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
-  }
-
-  logger.info("encodable", SomeType(1, "a"))
-  logger.info("encodable", "keyed" -> SomeType(2, "b"))
+//  logger.info("oi")
+//  logger.info("oi", "and" -> "tchau")
+//
+//  locally {
+//    // could drop the first field and just use a type encoder that will transform a string into a message
+//
+//    implicit object stringEncoder extends TypeEncoder[String] {
+//      override def encode(instance: String): Seq[(String, Value)] =
+//        Seq("message" -> StringValue(instance))
+//    }
+//
+//    implicit object symbolEncoder extends TypeEncoder[Symbol] {
+//      override def encode(instance: Symbol): Seq[(String, Value)] =
+//        Seq("message" -> StringValue(instance.name))
+//    }
+//
+//    logger.info("oi", "oi")
+//    logger.info("oi", 'oi_there)
+//  }
+//
+//  logger.info("log message", "hello" -> 123, "world" -> 456, "!" -> 789.0, "a" -> true, "b" -> 'b')
+//
+//  logger.info("log message", 'symbol -> 123)
+//  logger.info("log message", 'symbol -> 'to_symbol)
+//
+//  logger.info("sequence", "numbers" -> Seq(1, 2, 3))
+//  logger.info("set", "chars" -> Set('a', 'b', 'c'))
+//  logger.info("map", "ages" -> Map("me" -> 10, "you" -> 12))
+//  logger.info("map", "ages" -> Map('me -> 10, 'you -> 12))
+//
+//  logger.info("sequence", "numbers" -> Seq("vai" -> 123))
+//  logger.info("sequence", "numbers" -> Set("foi" -> 789))
+//  logger.info("sequence", "numbers" -> Map("is" -> Map("nested" -> Map("down" -> true, "up" -> false))))
+//
+//  logger.info("exception", new Exception("ex1"))
+//  logger.info("exception pair", "first" -> new Exception("ex2"))
+//
+//  logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
+//
+//  case class SomeType(int: Int, str: String) extends Encodable {
+//    override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
+//  }
+//
+//  logger.info("encodable", SomeType(1, "a"))
+//  logger.info("encodable", "keyed" -> SomeType(2, "b"))
 
 }

--- a/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
+++ b/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
@@ -1,55 +1,55 @@
 package com.unstablebuild.slime.examples
 
-import com.unstablebuild.slime.{Encodable, Logger, NumberValue, StringValue, TypeEncoder, Value}
+import com.unstablebuild.slime._
 
-object LoggerExamples extends App {
+object LoggerExamples extends App with TypeEncoders {
 
   val logger = Logger("hi")
 
-//  logger.info("oi")
-//  logger.info("oi", "and" -> "tchau")
-//
-//  locally {
-//    // could drop the first field and just use a type encoder that will transform a string into a message
-//
-//    implicit object stringEncoder extends TypeEncoder[String] {
-//      override def encode(instance: String): Seq[(String, Value)] =
-//        Seq("message" -> StringValue(instance))
-//    }
-//
-//    implicit object symbolEncoder extends TypeEncoder[Symbol] {
-//      override def encode(instance: Symbol): Seq[(String, Value)] =
-//        Seq("message" -> StringValue(instance.name))
-//    }
-//
-//    logger.info("oi", "oi")
-//    logger.info("oi", 'oi_there)
-//  }
-//
-//  logger.info("log message", "hello" -> 123, "world" -> 456, "!" -> 789.0, "a" -> true, "b" -> 'b')
-//
-//  logger.info("log message", 'symbol -> 123)
-//  logger.info("log message", 'symbol -> 'to_symbol)
-//
-//  logger.info("sequence", "numbers" -> Seq(1, 2, 3))
-//  logger.info("set", "chars" -> Set('a', 'b', 'c'))
-//  logger.info("map", "ages" -> Map("me" -> 10, "you" -> 12))
-//  logger.info("map", "ages" -> Map('me -> 10, 'you -> 12))
-//
-//  logger.info("sequence", "numbers" -> Seq("vai" -> 123))
-//  logger.info("sequence", "numbers" -> Set("foi" -> 789))
-//  logger.info("sequence", "numbers" -> Map("is" -> Map("nested" -> Map("down" -> true, "up" -> false))))
-//
-//  logger.info("exception", new Exception("ex1"))
-//  logger.info("exception pair", "first" -> new Exception("ex2"))
-//
-//  logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
-//
-//  case class SomeType(int: Int, str: String) extends Encodable {
-//    override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
-//  }
-//
-//  logger.info("encodable", SomeType(1, "a"))
-//  logger.info("encodable", "keyed" -> SomeType(2, "b"))
+  logger.info("oi")
+  logger.info("oi", "and" -> "tchau")
+
+  locally {
+    // could drop the first field and just use a type encoder that will transform a string into a message
+
+    implicit object stringEncoder extends TypeEncoder[String] {
+      override def encode(instance: String): Seq[(String, Value)] =
+        Seq("message" -> StringValue(instance))
+    }
+
+    implicit object symbolEncoder extends TypeEncoder[Symbol] {
+      override def encode(instance: Symbol): Seq[(String, Value)] =
+        Seq("message" -> StringValue(instance.name))
+    }
+
+    logger.info("oi", "oi")
+    logger.info("oi", 'oi_there)
+  }
+
+  logger.info("log message", "hello" -> 123, "world" -> 456, "!" -> 789.0, "a" -> true, "b" -> 'b')
+
+  logger.info("log message", 'symbol -> 123)
+  logger.info("log message", 'symbol -> 'to_symbol)
+
+  logger.info("sequence", "numbers" -> Seq(1, 2, 3))
+  logger.info("set", "chars" -> Set('a', 'b', 'c'))
+  logger.info("map", "ages" -> Map("me" -> 10, "you" -> 12))
+  logger.info("map", "ages" -> Map('me -> 10, 'you -> 12))
+
+  logger.info("sequence", "numbers" -> Seq("vai" -> 123))
+  logger.info("sequence", "numbers" -> Set("foi" -> 789))
+  logger.info("sequence", "numbers" -> Map("is" -> Map("nested" -> Map("down" -> true, "up" -> false))))
+
+  logger.info("exception", new Exception("ex1"))
+  logger.info("exception pair", "first" -> new Exception("ex2"))
+
+  logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
+
+  case class SomeType(int: Int, str: String) extends Encodable {
+    override def encoded: Seq[(String, Value)] = Seq("int" -> NumberValue(int), "str" -> StringValue(str))
+  }
+
+  logger.info("encodable", SomeType(1, "a"))
+  logger.info("encodable", "keyed" -> SomeType(2, "b"))
 
 }


### PR DESCRIPTION
This PR introduces a clean up on how the base type encoders are declared. There are a few type classes to help doing so:

- `Keyable`: defines that a certain type can be used as keys (i.e. `String` and `Symbol`);
- `Valuable`: defines that a type can be used as value;
- `Collection`: represents types that contain multiple values (`Seq`, `Set`, `Array`, `Option`, ...)