### PR TITLE
Create an encoder for case classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scalameta" %% "scalameta" % "1.8.0",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    "com.chuusai" %% "shapeless" % "2.3.2",
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "provided,test",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   ),

--- a/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
+++ b/macros/src/main/scala/com/unstablebuild/slime/TypeEncoder.scala
@@ -5,3 +5,9 @@ trait TypeEncoder[-T] {
   def encode(instance: T): Seq[(String, Value)]
 
 }
+
+object TypeEncoder {
+
+  def apply[T](implicit te: TypeEncoder[T]): TypeEncoder[T] = te
+
+}

--- a/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/TypeEncodersTest.scala
@@ -98,6 +98,17 @@ class TypeEncodersTest extends FlatSpec with MustMatchers with TypeEncoders {
     encode("hello" -> Option("hi")) must equal(Seq("hello" -> SeqValue(Seq(StringValue("hi")))))
   }
 
+  it must "encode case classes" in {
+
+    case class HelloWorld(i: Int, s: String)
+
+    encode(HelloWorld(1, "oi")) must equal(Seq("i" -> NumberValue(1), "s" -> StringValue("oi")))
+
+    encode("keyed" -> HelloWorld(1, "oi")) must equal(
+      Seq("keyed" -> NestedValue(Seq("i" -> NumberValue(1), "s" -> StringValue("oi"))))
+    )
+  }
+
   def encode[T](instance: T)(implicit te: TypeEncoder[T]): Seq[(String, Value)] =
     te.encode(instance)
 

--- a/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
+++ b/src/test/scala/com/unstablebuild/slime/examples/LoggerExamples.scala
@@ -43,4 +43,8 @@ object LoggerExamples extends App with LazyLogging {
 
   logger.info("nested", "going" -> ("down" -> ("the" -> ("rabbit" -> "hole"))))
 
+  case class Hello(name: String)
+
+  logger.info("hello", "nicknames" -> Map("lucas" -> Hello("Lucas"), "leonardo" -> Hello("Leo")))
+
 }


### PR DESCRIPTION
The unit test says it all:

```scala
it must "encode case classes" in {

  case class HelloWorld(i: Int, s: String)

  encode(HelloWorld(1, "oi")) must equal(Seq("i" -> NumberValue(1), "s" -> StringValue("oi")))

  encode("keyed" -> HelloWorld(1, "oi")) must equal(
    Seq("keyed" -> NestedValue(Seq("i" -> NumberValue(1), "s" -> StringValue("oi"))))
  )
}
```