### PR TITLE
Implement a minimal JSON format without external libs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ val commonSettings = Seq(
     "org.scalameta" %% "scalameta" % "1.8.0",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "provided,test",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "com.typesafe.play" %% "play-json" % "2.6.0" % "test"
   ),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
   releaseProcess := Seq[ReleaseStep](

--- a/src/main/scala/com/unstablebuild/slime/format/Json.scala
+++ b/src/main/scala/com/unstablebuild/slime/format/Json.scala
@@ -6,19 +6,58 @@ import com.unstablebuild.slime._
 
 class Json extends Format {
 
-  override def format(values: Seq[(String, Value)]): Array[Byte] = {
-    (formatNested(values) + "\n").getBytes(StandardCharsets.UTF_8)
+  override def format(values: Seq[(String, Value)]): Array[Byte] =
+    formatValue(NestedValue(values))(StringBuilder.newBuilder).append("\n").toString().getBytes(StandardCharsets.UTF_8)
+
+  private def formatValue(value: Value)(implicit builder: StringBuilder): StringBuilder = value match {
+    case NumberValue(num) =>
+      builder.append(num.toString)
+    case BooleanValue(b) =>
+      builder.append(b.toString)
+    case StringValue(str) =>
+      builder.append('"')
+      formatString(str)
+      builder.append('"')
+    case SeqValue(values) =>
+      builder.append('[')
+      if (values.nonEmpty) {
+        formatValue(values.head)
+        for (next <- values.tail) {
+          builder.append(',')
+          formatValue(next)
+        }
+      }
+      builder.append(']')
+    case NestedValue(values) =>
+      @inline
+      def appendPair(pair: (String, Value)): Unit = {
+        builder.append('"')
+        formatString(pair._1)
+        builder.append("\":")
+        formatValue(pair._2)
+      }
+
+      builder.append("{")
+      if (values.nonEmpty) {
+        appendPair(values.head)
+        for (next <- values.tail) {
+          builder.append(',')
+          appendPair(next)
+        }
+      }
+      builder.append("}")
   }
 
-  private def formatValue(value: Value): String = value match {
-    case SeqValue(values) => values.map(formatValue).mkString("[", ",", "]")
-    case StringValue(str) => "\"" + str.replaceAll("\n", "\\\\n").replaceAll("\t", "\\\\t") + "\""
-    case NumberValue(num) => num.toString
-    case BooleanValue(b) => b.toString
-    case NestedValue(values) => formatNested(values)
+  private def formatString(str: String)(implicit builder: StringBuilder): Unit = str.foreach {
+    case '\b' => builder.append("\\b")
+    case '\f' => builder.append("\\f")
+    case '\n' => builder.append("\\n")
+    case '\r' => builder.append("\\r")
+    case '\t' => builder.append("\\t")
+    case '"' => builder.append("\\\"")
+    case '\\' => builder.append("\\\\")
+    case c if Character.isISOControl(c) => builder.append('\\').append("u%04x".format(c.toInt))
+    case other => builder.append(other)
   }
-
-  private def formatNested(values: Seq[(String, Value)]): String =
-    values.map { case (k, v) => "\"" + k + "\":" + formatValue(v) }.mkString("{", ",", "}")
 
 }

--- a/src/test/scala/com/unstablebuild/slime/format/JsonTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/format/JsonTest.scala
@@ -1,0 +1,61 @@
+package com.unstablebuild.slime.format
+
+import java.nio.charset.StandardCharsets
+
+import com.unstablebuild.slime._
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.{FlatSpec, MustMatchers}
+import play.api.libs.json.{Json => PlayJson}
+
+class JsonTest extends FlatSpec with MustMatchers {
+
+  val format = new Json
+
+  it must "produce valid json for all fields" in {
+    formatted(
+      Seq(
+        "s" -> StringValue("hello!"),
+        "ni" -> NumberValue(7),
+        "nf" -> NumberValue(3.4567),
+        "b" -> BooleanValue(false)
+      )
+    ) must matchJson("""{"s":"hello!","ni":7,"nf":3.4567,"b":false}""")
+  }
+
+  it must "format nested objects" in {
+    formatted(
+      Seq(
+        "obj" -> NestedValue(
+          Seq("nested" -> NestedValue(Seq("yes" -> BooleanValue(true), "no" -> BooleanValue(false))))
+        )
+      )
+    ) must matchJson("""{"obj":{"nested":{"yes":true,"no":false}}}""")
+  }
+
+  it must "format arrays" in {
+    formatted(Seq("array" -> SeqValue(Seq(NumberValue(5.1), NestedValue(Seq("obj" -> StringValue("nested"))))))) must matchJson(
+      """{"array":[5.1,{"obj":"nested"}]}"""
+    )
+  }
+
+  it must "escape strings" in {
+    formatted(Seq("hello" -> StringValue("a\tstring\nmust\bbe\rencoded"))) must matchJson(
+      """{"hello":"a\tstring\nmust\bbe\rencoded"}"""
+    )
+  }
+
+  def formatted(values: Seq[(String, Value)]): String =
+    new String(format.format(values), StandardCharsets.UTF_8)
+
+  def matchJson(expected: String): Matcher[String] = { str =>
+    val expectedJson = PlayJson.parse(expected)
+    val givenJson = PlayJson.parse(str)
+
+    MatchResult(
+      str.endsWith("\n") && expectedJson == givenJson,
+      s"""JSON $givenJson did not match $expectedJson"""",
+      s"""JSON $givenJson matched $expectedJson"""
+    )
+  }
+
+}


### PR DESCRIPTION
Using the `Json` format, each logged entry will be converted into a single line of JSON. No JSON libs are used, with the exception of the unit test, that use them to validate the output.