### PR TITLE
Add configuration to set custom field extractor

### DIFF
--- a/src/main/scala/com/unstablebuild/slime/field/DefaultFieldExtractor.scala
+++ b/src/main/scala/com/unstablebuild/slime/field/DefaultFieldExtractor.scala
@@ -1,0 +1,40 @@
+package com.unstablebuild.slime.field
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneOffset}
+
+import ch.qos.logback.classic.spi.LoggingEvent
+import com.unstablebuild.slime.{NestedValue, NumberValue, StringValue, Value}
+
+import scala.collection.JavaConverters._
+
+class DefaultFieldExtractor extends FieldExtractor {
+
+  override def extract(field: String, event: LoggingEvent): Option[Value] =
+    DefaultFieldExtractor.fieldExtractors.get(field).map(_.apply(event))
+
+}
+
+object DefaultFieldExtractor {
+
+  private val dateFormatter = DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(ZoneOffset.UTC)
+
+  val fieldExtractors: Map[String, LoggingEvent => Value] =
+    Map(
+      "level" -> (e => StringValue(e.getLevel.toString)),
+      "message" -> (e => StringValue(e.getFormattedMessage)),
+      "thread" -> (e => StringValue(e.getThreadName)),
+      "logger" -> (e => StringValue(e.getLoggerName)),
+      "mdc" -> (e => NestedValue(e.getMDCPropertyMap.asScala.mapValues(StringValue).toSeq)),
+      "timestamp" -> (e => NumberValue(e.getTimeStamp)),
+      "ts" -> (e => StringValue(dateFormatter.format(Instant.ofEpochMilli(e.getTimeStamp)))),
+      "caller" -> (e => StringValue(caller(e.getCallerData)))
+    )
+
+  // The first entry comes from the logger library, being the 2nd element the actual caller
+  private def caller(stack: Array[StackTraceElement]): String = stack match {
+    case Array(_, c, _ *) => s"(${c.getFileName}:${c.getLineNumber})"
+    case _ => "unknown"
+  }
+
+}

--- a/src/main/scala/com/unstablebuild/slime/field/FieldExtractor.scala
+++ b/src/main/scala/com/unstablebuild/slime/field/FieldExtractor.scala
@@ -1,0 +1,10 @@
+package com.unstablebuild.slime.field
+
+import ch.qos.logback.classic.spi.LoggingEvent
+import com.unstablebuild.slime.Value
+
+trait FieldExtractor {
+
+  def extract(field: String, event: LoggingEvent): Option[Value]
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="com.unstablebuild.slime.Encoder">
       <format class="com.unstablebuild.slime.format.ColoredText" />
-      <fields>level,logger,thread,message</fields>
+      <fields>level,ts,caller,logger,thread,message</fields>
     </encoder>
   </appender>
   <root level="all">

--- a/src/test/scala/com/unstablebuild/slime/EncoderTest.scala
+++ b/src/test/scala/com/unstablebuild/slime/EncoderTest.scala
@@ -46,7 +46,7 @@ class EncoderTest extends FlatSpec with MustMatchers { self =>
     encoder.encode(event(ts = 12345L))
 
     format.receivedValues must equal(
-      Seq("timestamp" -> NumberValue(12345L), "ts" -> StringValue("1970-01-01T03:25:45Z"))
+      Seq("timestamp" -> NumberValue(12345L), "ts" -> StringValue("1970-01-01T00:00:12.345Z"))
     )
   }
 


### PR DESCRIPTION
This addresses #10 and also fixes a bug on the field `ts`.

That's how it is looking like:

<img width="1734" alt="screen shot 2017-08-22 at 8 46 45 pm" src="https://user-images.githubusercontent.com/347716/29581883-0f4534ae-877b-11e7-9f9f-e27c9dc1d527.png">

I was looking for a mechanism to allow the user to extract their own content from the `LoggingEvent`. I.e., should a stack trace be a string of a sequence of strings for each line? Instead of trying to figure it out, I'm still providing a default, but the user can now plug their own `FieldExtractor`.