### PR TITLE
add plugins that enable publishing to sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,38 +1,66 @@
-import ReleaseTransformations._
-
 val commonSettings = Seq(
-  version := "0.2.0",
+  version := "0.2.1",
   scalaVersion := "2.12.3",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   crossScalaVersions := Seq("2.12.3"),
   organization := "com.unstablebuild",
+  homepage := Some(url("https://github.com/petterarvidsson/slime")),
+  organizationHomepage := Some(url("https://github.com/petterarvidsson/slime")),
   licenses := Seq("MIT License" -> url("https://opensource.org/licenses/MIT")),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
   libraryDependencies ++= Seq(
-    "org.scalameta" %% "scalameta" % "1.8.0",
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "com.chuusai" %% "shapeless" % "2.3.2",
     "ch.qos.logback" % "logback-classic" % "1.2.3" % "provided,test",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "com.typesafe.play" %% "play-json" % "2.6.0" % "test"
   ),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
+  publishMavenStyle := true,
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+    else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  },
+  publishArtifact in Test := false,
+  pomIncludeRepository := (_ => false),
+  pomExtra :=
+    <scm>
+      <url>git@github.com:petterarvidsson/slime.git</url>
+      <connection>scm:git:git@github.com:petterarvidsson/slime.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <id>petterarvidsson</id>
+        <name>Petter Arvidsson</name>
+        <url>https://github.com/petterarvidsson</url>
+      </developer>
+      <developer>
+        <id>hansjoergschurr</id>
+        <name>Hans-Jörg Schurr</name>
+        <url>https://github.com/hansjoergschurr</url>
+      </developer>
+      <developer>
+        <id>lucastorri</id>
+        <name>Lucas Torri</name>
+        <url>http://unstablebuild.com</url>
+      </developer>
+      <developer>
+        <id>hcwilhelm</id>
+        <name>Hans Christian Wilhelm</name>
+        <url>https://github.com/hcwilhelm</url>
+      </developer>
+    </developers>
 )
 
 lazy val macros = project
   .in(file("macros"))
   .settings(commonSettings: _*)
-  .settings(name := "slime-macros")
+  .settings(
+    name := "slime-macros",
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scalameta" %% "scalameta" % "1.8.0"
+    )
+  )
 
 lazy val root = project
   .in(file("."))

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.0")

--- a/project/gpg.sbt
+++ b/project/gpg.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/project/release.sbt
+++ b/project/release.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")

--- a/project/sonatype.sbt
+++ b/project/sonatype.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
I'm moving a step back from `sbt-release` and just using what I was used to: gpg + sonatype plugins.

http://central.maven.org/maven2/com/unstablebuild/slime_2.12/0.2.0/

This requires a few manual steps and my GPG credentials. We can figure out a better way later, but I wanted to get this out of the door.